### PR TITLE
Simplify Nginx configuration and remove unnecessary location blocks

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -11,9 +11,4 @@ server {
     
     # 明示的な404エラーハンドリング
     error_page 404 /public/404.html;
-    
-    # /public パスへのアクセス
-    location /public {
-        try_files $uri $uri/ /public/404.html;
-    }
 }


### PR DESCRIPTION
## 概要
Nginxの設定において、/public 以下のパスを明示的に処理する location ブロックは不要であると判断し、削除しました。これにより、シンプルな設定で意図した動作（存在しないURLにアクセスされた場合に 404.html を返す）を維持できます。

## 変更点
- location /public ブロックを削除
- / の try_files によって public/404.html を適切に処理する形に統一
- 設定の冗長性を削減し、メンテナンス性を向上

## 動作確認
- 存在するファイルにアクセス → 正常に表示されることを確認
- 存在しないファイルにアクセス → public/404.html が表示されることを確認