### PR TITLE
CSS cleanup & layout adjustment changes & updated 404 page colors

### DIFF
--- a/client/public/404.html
+++ b/client/public/404.html
@@ -13,7 +13,7 @@
         }
         h1 {
             font-size: 50px;
-            color: #ff6347;
+            color: #1597CC;
         }
         h2 {
             font-size: 30px;
@@ -29,12 +29,12 @@
             padding: 10px 20px;
             font-size: 18px;
             color: white;
-            background-color: #ff6347;
+            background-color: #1597CC;
             text-decoration: none;
             border-radius: 5px;
         }
         a:hover {
-            background-color: #e5533d;
+            background-color: #0f78a1;
         }
     </style>
 </head>

--- a/client/public/style.css
+++ b/client/public/style.css
@@ -26,7 +26,6 @@
 /* ============ Default Styles ============ */
 body {
     font-family: 'Roboto', Arial, sans-serif;
-    /* font-size: 16px; */
     line-height: 1.5;
     background-color: var(--background-color);
 }

--- a/client/public/style.css
+++ b/client/public/style.css
@@ -26,7 +26,7 @@
 /* ============ Default Styles ============ */
 body {
     font-family: 'Roboto', Arial, sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     line-height: 1.5;
     background-color: var(--background-color);
 }
@@ -122,17 +122,13 @@ button:hover {
 
 /* ============ Todo List Styles ============ */
 #todo-list {
-    list-style: none;
     padding: 0;
-    margin-top: 1rem;
-    flex: 1;
+    flex: 0.9;
 }
 
 #todo-list li {
-    background: var(--list-item-background-color);
     margin: 0.5rem 0;
     padding: 0.5rem;
-    border-radius: 5px;
     display: flex;
     align-items: center;
     border: 1px solid var(--border-color);

--- a/client/public/style.css
+++ b/client/public/style.css
@@ -127,7 +127,7 @@ button:hover {
 }
 
 #todo-list li {
-    margin: 0.5rem 0;
+    margin: 1rem 0;
     padding: 0.5rem;
     display: flex;
     align-items: center;


### PR DESCRIPTION
## 概要
**CSS**
- 実際に効いていないコードを取り除き、CSS をスリム化して可読性・保守性を向上。
- レイアウト調整でページネーションとリスト間のスペースを適切化。

**HTML**
- アプリ全体の配色（メインカラー）と統一。

## 変更内容
**CSS**
- style.css から不要になったコメントアウト済みプロパティを削除。
- `#todo-list` の flex を 1 → 0.9 に変更
  - リスト領域を少し縮め、ページネーションとの隙間を狭めつつバランスを最適化。
- Todoリスト項目の上下マージンを 0.5rem → 1rem に拡大し、項目同士の間隔を広げて可読性を向上。
 
**HTML**
- 404ページの見出し (h1) の文字色、リンクボタン、ホバーの背景色をブランドブルーに変更。

## 動作検証
- 既存ビューでリスト表示に影響がないことを確認。
- ブラウザデフォルトのマーカーや余白が復活していないことをチェック。