### PR TITLE
increase list item spacing from 1rem to 0.5rem

### DIFF
--- a/client/public/style.css
+++ b/client/public/style.css
@@ -126,7 +126,7 @@ button:hover {
 }
 
 #todo-list li {
-    margin: 1rem 0;
+    margin: 0.5rem 0;
     padding: 0.5rem;
     display: flex;
     align-items: center;


### PR DESCRIPTION
### 変更内容
- プルリクエストの概要
- https://github.com/Action0358/todo-app-lite/pull/42
> Todoリスト項目の上下マージンを 0.5rem → 1rem に拡大し、項目同士の間隔を広げて可読性を向上。

上記の修正内容を切り戻しを実施。